### PR TITLE
use $this->task() to call task within trait

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "php": ">=5.4.0"
     },
     "require-dev": {
-        "codegyre/robo": "^0.5.4",
+        "consolidation/robo": "^1.0",
         "phpunit/phpunit": "^4.4.5",
         "robmorgan/phinx": "^0.4.6"
     }

--- a/src/Phinx.php
+++ b/src/Phinx.php
@@ -10,7 +10,7 @@ trait Phinx
 {
     protected function taskPhinx($pathToPhinx = null)
     {
-        return new PhinxTask($pathToPhinx);
+        return $this->task(PhinxTask::class, $pathToPhinx);
     }
 }
 

--- a/test/PhinxTest.php
+++ b/test/PhinxTest.php
@@ -8,6 +8,11 @@ class PhinxTest extends PHPUnit_Framework_TestCase
 {
     use Phinx;
 
+    protected function task($class, $pathToPhinx = null)
+    {
+        return new $class($pathToPhinx);
+    }
+
     public function testTraitExists()
     {
         $this->assertTrue(method_exists($this, 'taskPhinx'));


### PR DESCRIPTION
First, thanks for this project, it was nice to find something that was already put together for this.

This change prevents newer versions of Robo from complaining with the following error:

> ERROR: No logger set for Rb\Robo\Task\PhinxTask. Use $this->task(Foo::class) rather than new Foo() in loadTasks to ensure the builder can initialize task the task, or use $this->collectionBuilder()->taskFoo() if creating one task from within another.
> in .../vendor/consolidation/robo/src/Common/TaskIO.php:42

I've also bumped up to a more current robo dependency, and adjusted the tests so that they still pass (tested on php 7.2.4).